### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51309, Total PRs: 9015, Total PRs Merged: 8986, Total PRs Reviewed: 8735, Total Issues: 8914, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51314, Total PRs: 9015, Total PRs Merged: 8987, Total PRs Reviewed: 8735, Total Issues: 8915, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` to bring the latest generated GitHub statistics and visualizations. Updates `assets/github-stats.svg` with refreshed counts (commits, merged PRs, issues) to keep dashboards consistent.

<sup>Written for commit da2ea0e08833647286066bb66a9fab893f43bdf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

