### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51314, Total PRs: 9015, Total PRs Merged: 8987, Total PRs Reviewed: 8735, Total Issues: 8915, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51320, Total PRs: 9016, Total PRs Merged: 8988, Total PRs Reviewed: 8735, Total Issues: 8919, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `main` into `develop` to bring in the latest GitHub stats and visualization updates. Updates `assets/github-stats.svg` with refreshed metrics (commits, PRs, merged PRs, issues) to keep the dashboard current.

<sup>Written for commit 3c800c0a68b81a16a44385c8a01282d5280b11e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

