### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51320, Total PRs: 9016, Total PRs Merged: 8988, Total PRs Reviewed: 8735, Total Issues: 8919, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51324, Total PRs: 9017, Total PRs Merged: 8989, Total PRs Reviewed: 8735, Total Issues: 8920, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the GitHub stats visualization with the latest counts. Updated `assets/github-stats.svg` to reflect: commits 51324 (was 51320), PRs 9017 (was 9016), merged PRs 8989 (was 8988), issues 8920 (was 8919).

<sup>Written for commit 34a8676102149ff567cf195113a585b0e33c49d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

