### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51391, Total PRs: 9028, Total PRs Merged: 9000, Total PRs Reviewed: 8735, Total Issues: 8940, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51395, Total PRs: 9029, Total PRs Merged: 9001, Total PRs Reviewed: 8735, Total Issues: 8941, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `main` into `develop` to keep the GitHub Stats & Visualizations work aligned and up to date. Refreshed metrics in `assets/github-stats.svg`; no functional changes.

<sup>Written for commit ccf556d100e0ae6f3dada6ed46607bcddd13c520. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

