### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51395, Total PRs: 9029, Total PRs Merged: 9001, Total PRs Reviewed: 8735, Total Issues: 8941, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51399, Total PRs: 9030, Total PRs Merged: 9002, Total PRs Reviewed: 8735, Total Issues: 8942, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` to pull in the latest GitHub stats visualization. Updates `assets/github-stats.svg` with refreshed counts (commits 51399, PRs 9030, merged PRs 9002, issues 8942); no functional changes.

<sup>Written for commit 2256f1cd264637d05bc08d3500b1f3cbf5581b90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

