### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51435, Total PRs: 9038, Total PRs Merged: 9008, Total PRs Reviewed: 8735, Total Issues: 8951, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51443, Total PRs: 9039, Total PRs Merged: 9009, Total PRs Reviewed: 8735, Total Issues: 8953, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` to pick up the latest GitHub stats and visualization updates. Updates `assets/github-stats.svg` numbers (commits 51443, PRs 9039, merged PRs 9009, issues 8953) to match `main`; no feature changes.

<sup>Written for commit a43fba305a6e99955a5487510c05187a26a72d40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

