### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51443, Total PRs: 9039, Total PRs Merged: 9009, Total PRs Reviewed: 8735, Total Issues: 8953, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 21, Total Commits  : 51458, Total PRs: 9042, Total PRs Merged: 9012, Total PRs Reviewed: 8735, Total Issues: 8956, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -177,7 +177,7 @@
         x="219.01"
         y="12.5"
         data-testid="commits"
-      >51.4k</text>
+      >51.5k</text>
     </g>
   </g><g transform="translate(0, 50)">
     <g class="stagger" style="animation-delay: 750ms" transform="translate(25, 0)">


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `main` into `develop` to bring the latest GitHub stats visualization updates. Updates `assets/github-stats.svg` with refreshed counts (commits 51.5k, PRs 9042 with 9012 merged, issues 8956); no feature or behavior changes.

<sup>Written for commit 8f360d1ca15670651956a6101847acf793124cec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

