### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51485, Total PRs: 9046, Total PRs Merged: 9017, Total PRs Reviewed: 8735, Total Issues: 8962, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51490, Total PRs: 9047, Total PRs Merged: 9018, Total PRs Reviewed: 8735, Total Issues: 8963, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and updates `assets/github-stats.svg` with the latest counts (commits +5, PRs +1, merged PRs +1, issues +1). No functional changes—merge-only to keep dashboards and CI consistent.

<sup>Written for commit 13eb87c6dc5570a25d4690b50442a8a896550a9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

