### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51539, Total PRs: 9058, Total PRs Merged: 9028, Total PRs Reviewed: 8735, Total Issues: 8974, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51544, Total PRs: 9060, Total PRs Merged: 9029, Total PRs Reviewed: 8735, Total Issues: 8975, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `main` into `develop` to bring in the latest GitHub stats and visualization updates, including refreshed values in `assets/github-stats.svg`. No functional changes; this removes branch drift and keeps auto-generated reports consistent.

<sup>Written for commit e91624d481c8a590e9122d1d536e49e3907ee9cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

