### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51544, Total PRs: 9060, Total PRs Merged: 9029, Total PRs Reviewed: 8735, Total Issues: 8975, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51550, Total PRs: 9061, Total PRs Merged: 9030, Total PRs Reviewed: 8735, Total Issues: 8977, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `main` into `develop` with the latest auto-updated GitHub stats visualization. Updates `assets/github-stats.svg` counts only (commits 51544→51550, PRs 9060→9061, merged 9029→9030, issues 8975→8977); no functional changes.

<sup>Written for commit eb4976cabac03a4cb09e48d7965135c1bbfe4518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

