### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51573, Total PRs: 9065, Total PRs Merged: 9035, Total PRs Reviewed: 8735, Total Issues: 8984, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51578, Total PRs: 9065, Total PRs Merged: 9036, Total PRs Reviewed: 8735, Total Issues: 8985, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the GitHub stats visualization by updating counts in `assets/github-stats.svg` so the profile badge stays accurate. Updated totals: commits 51578 (was 51573), PRs merged 9036 (was 9035), issues 8985 (was 8984).

<sup>Written for commit b139d082e2c4df23b0724b344a86aa7715a4d9ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

