### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51578, Total PRs: 9065, Total PRs Merged: 9036, Total PRs Reviewed: 8735, Total Issues: 8985, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51583, Total PRs: 9067, Total PRs Merged: 9037, Total PRs Reviewed: 8735, Total Issues: 8986, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Back-merge main into develop to refresh generated GitHub stats and visualizations. Updates assets/github-stats.svg numbers (commits 51583; PRs 9067, merged 9037; issues 8986; stars 22; contributed 24) to keep dashboards current.

<sup>Written for commit 80a660e9a5ccc38152bf589d93030877570c5864. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

