### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">FrancoStino's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51602, Total PRs: 9070, Total PRs Merged: 9041, Total PRs Reviewed: 8735, Total Issues: 8991, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 22, Total Commits  : 51607, Total PRs: 9071, Total PRs Merged: 9042, Total PRs Reviewed: 8735, Total Issues: 8992, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and refreshes generated GitHub stats so dashboards show the latest data. Updates `assets/github-stats.svg` counts (commits 51607, PRs 9071, merged PRs 9042, issues 8992); no functional code changes.

<sup>Written for commit 43162483760e28b55cc778f37327de8e3fd63ae0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

