### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 25, Total Commits  : 51649, Total PRs: 9080, Total PRs Merged: 9051, Total PRs Reviewed: 8735, Total Issues: 9003, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51655, Total PRs: 9082, Total PRs Merged: 9052, Total PRs Reviewed: 8735, Total Issues: 9006, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -73,7 +73,7 @@
         stroke-dashoffset: 251.32741228718345;
       }
       to {
-        stroke-dashoffset: 64.9566017263977;
+        stroke-dashoffset: 64.22172625187375;
       }
     }
   
@@ -162,7 +162,7 @@
         x="219.01"
         y="12.5"
         data-testid="stars"
-      >25</text>
+      >26</text>
     </g>
   </g><g transform="translate(0, 25)">
     <g class="stagger" style="animation-delay: 600ms" transform="translate(25, 0)">
@@ -177,7 +177,7 @@
         x="219.01"
         y="12.5"
         data-testid="commits"
-      >51.6k</text>
+      >51.7k</text>
     </g>
   </g><g transform="translate(0, 50)">
     <g class="stagger" style="animation-delay: 750ms" transform="translate(25, 0)">


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and updates the GitHub stats SVG to reflect the latest counts (stars, commits, PRs, issues). No functional changes; resolves branch divergence and refreshes visualizations.

<sup>Written for commit 5cc774529e477f44aad2934dd93d432e5a2847d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

