### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51659, Total PRs: 9082, Total PRs Merged: 9053, Total PRs Reviewed: 8735, Total Issues: 9007, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51664, Total PRs: 9083, Total PRs Merged: 9054, Total PRs Reviewed: 8735, Total Issues: 9008, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync main to develop to pull in the latest GitHub stats visualization update. `assets/github-stats.svg` now reflects refreshed counts (commits 51664, PRs 9083, merged PRs 9054, issues 9008); no functional code changes.

<sup>Written for commit 4532b1d6a33840084c2f5d8fca9156207fad57ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

