### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51664, Total PRs: 9083, Total PRs Merged: 9054, Total PRs Reviewed: 8735, Total Issues: 9008, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51668, Total PRs: 9085, Total PRs Merged: 9055, Total PRs Reviewed: 8735, Total Issues: 9009, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` to keep GitHub Stats & Visualizations current. Refreshes metrics in `assets/github-stats.svg` (commits, PRs, issues); no functional changes.

<sup>Written for commit 48be53226badb47ac0afe7206488098ab4f65685. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

