### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51668, Total PRs: 9085, Total PRs Merged: 9055, Total PRs Reviewed: 8735, Total Issues: 9009, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51674, Total PRs: 9086, Total PRs Merged: 9056, Total PRs Reviewed: 8735, Total Issues: 9011, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` to bring in the latest GitHub stats refresh, updating `assets/github-stats.svg` counts (commits 51674, PRs 9086/9056 merged, issues 9011).
No new code; merges previously released changes.

<sup>Written for commit d5bd0d884517ef1d2e06421c44cf56d43c612124. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

