### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51679, Total PRs: 9086, Total PRs Merged: 9057, Total PRs Reviewed: 8735, Total Issues: 9012, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51684, Total PRs: 9087, Total PRs Merged: 9058, Total PRs Reviewed: 8735, Total Issues: 9013, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and updates `assets/github-stats.svg` with the latest GitHub counts (commits, PRs, merged PRs, issues). No functional changes; resolves branch drift and keeps dashboards and visualizations consistent.

<sup>Written for commit b09f93c564535aea712d8ae775a636c240a47be1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

