### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51684, Total PRs: 9087, Total PRs Merged: 9058, Total PRs Reviewed: 8735, Total Issues: 9013, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51688, Total PRs: 9088, Total PRs Merged: 9059, Total PRs Reviewed: 8735, Total Issues: 9014, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `main` into `develop` to auto-update GitHub stats and visualizations, keeping dashboards current.
Updates counts in `assets/github-stats.svg` (commits, PRs, merged PRs, issues); no app code changes.

<sup>Written for commit 7a39b8cc4e0e090be71c2f9c901dd25d1a39de53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

