### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51688, Total PRs: 9088, Total PRs Merged: 9059, Total PRs Reviewed: 8735, Total Issues: 9014, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51692, Total PRs: 9089, Total PRs Merged: 9060, Total PRs Reviewed: 8735, Total Issues: 9015, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and brings in the latest auto-updated GitHub stats; updates numbers in `assets/github-stats.svg` (commits, PRs, merged PRs, issues). No functional changes; this prevents branch drift and future merge conflicts.

<sup>Written for commit 6a96ac3e330b36c8b9ca4592a03779b966006e1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

