### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A-</title>
-        <desc id="descId">Total Stars Earned: 26, Total Commits  : 51692, Total PRs: 9089, Total PRs Merged: 9060, Total PRs Reviewed: 8735, Total Issues: 9015, Contributed to (last year): 24</desc>
+        <desc id="descId">Total Stars Earned: 27, Total Commits  : 51697, Total PRs: 9090, Total PRs Merged: 9061, Total PRs Reviewed: 8735, Total Issues: 9016, Contributed to (last year): 24</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -73,7 +73,7 @@
         stroke-dashoffset: 251.32741228718345;
       }
       to {
-        stroke-dashoffset: 64.22172625187375;
+        stroke-dashoffset: 63.50593845201277;
       }
     }
   
@@ -162,7 +162,7 @@
         x="219.01"
         y="12.5"
         data-testid="stars"
-      >26</text>
+      >27</text>
     </g>
   </g><g transform="translate(0, 25)">
     <g class="stagger" style="animation-delay: 600ms" transform="translate(25, 0)">


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync main into develop; refresh `assets/github-stats.svg` with latest GitHub stats and animation values. No product changes; housekeeping only.

<sup>Written for commit aa82c9e7c0d757eb111c5953bc7f21ef4780cc01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

