### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A</title>
-        <desc id="descId">Total Stars Earned: 61, Total Commits  : 52641, Total PRs: 9259, Total PRs Merged: 9225, Total PRs Reviewed: 8729, Total Issues: 9235, Contributed to (last year): 26</desc>
+        <desc id="descId">Total Stars Earned: 61, Total Commits  : 52648, Total PRs: 9260, Total PRs Merged: 9226, Total PRs Reviewed: 8729, Total Issues: 9236, Contributed to (last year): 26</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and refreshes `assets/github-stats.svg` with updated counts (commits 52,648; PRs 9,260; merged 9,226; issues 9,236) to keep stats and visualizations current.

<sup>Written for commit 25e89945a8d7cf4d01506697ef7b7bdf8abc7f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/FrancoStino/pull/30508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

