### PR TITLE
🤖 Auto-update: GitHub Stats & Visualizations

### DIFF
--- a/assets/github-stats.svg
+++ b/assets/github-stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Davide Ladisa's GitHub Stats, Rank: A</title>
-        <desc id="descId">Total Stars Earned: 65, Total Commits  : 52710, Total PRs: 9273, Total PRs Merged: 9236, Total PRs Reviewed: 8729, Total Issues: 9242, Contributed to (last year): 26</desc>
+        <desc id="descId">Total Stars Earned: 65, Total Commits  : 52719, Total PRs: 9275, Total PRs Merged: 9237, Total PRs Reviewed: 8729, Total Issues: 9243, Contributed to (last year): 26</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;

--- a/assets/github-streak.svg
+++ b/assets/github-streak.svg
@@ -33,7 +33,7 @@
                 <!-- Total Contributions big number -->
                 <g transform='translate(82.5, 48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#70A5FD' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
-                        83,191
+                        83,204
                     </text>
                 </g>
 
@@ -62,7 +62,7 @@
                 <!-- Current Streak range -->
                 <g transform='translate(247.5, 145)'>
                     <text x='0' y='21' stroke-width='0' text-anchor='middle' fill='#38BDAE' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
-                        Dec 1, 2025 - Jun 28
+                        Dec 1, 2025 - Jun 29
                     </text>
                 </g>
 
@@ -79,7 +79,7 @@
                 <!-- Current Streak big number -->
                 <g transform='translate(247.5, 48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#BF91F3' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='animation: currstreak 0.6s linear forwards'>
-                        210
+                        211
                     </text>
                 </g>
 
@@ -88,7 +88,7 @@
                 <!-- Longest Streak big number -->
                 <g transform='translate(412.5, 48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#70A5FD' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
-                        210
+                        211
                     </text>
                 </g>
 
@@ -102,7 +102,7 @@
                 <!-- Longest Streak range -->
                 <g transform='translate(412.5, 114)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#38BDAE' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
-                        Dec 1, 2025 - Jun 28
+                        Dec 1, 2025 - Jun 29
                     </text>
                 </g>
             </g>


### PR DESCRIPTION
Aggiornamento automatico da develop a main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` into `develop` and refreshes GitHub stats visuals with the latest totals and streak data in `assets/github-stats.svg` and `assets/github-streak.svg`. No functional changes; resolves branch drift and keeps metrics up to date.

<sup>Written for commit e83fc6cf9a8395d422f37a9e87e455195bc310c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/FrancoStino/pull/30530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

